### PR TITLE
Initial terraform scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,16 @@
 
 # .tfvars files
 *.tfvars
+
+# credentials file
+credentials
+
+# Emacs files
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Terraform Scripts for AWS
+
+Terraform scripts to provision AWS servers to execute performance tests
+
+## Getting Started
+
+For convenience a Vagrant machine with GNU/Linux and the latest
+version Terraform is installed by running `agrant up` in the root
+directory (As of this writing Terraform v0.11.1).
+
+Make sure your AWS credentials are linked to this directory, so it can be accessed inside the vagrant box. For example:
+
+```
+cp ~/.aws/credentials .
+```
+
+~/.aws/credentials
+```
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+## Debugging
+```
+export TF_LOG=DEBUG
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform scripts to provision AWS servers to execute performance tests
 ## Getting Started
 
 For convenience a Vagrant machine with GNU/Linux and the latest
-version Terraform is installed by running `agrant up` in the root
+version Terraform is installed by running `vagrant up` in the root
 directory (As of this writing Terraform v0.11.1).
 
 Make sure your AWS credentials are linked to this directory, so it can be accessed inside the vagrant box. For example:

--- a/aws-policies/README.md
+++ b/aws-policies/README.md
@@ -1,0 +1,11 @@
+# IAM Policies
+
+## Custom Policies
+Policy: Working With Instances
+Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ExamplePolicies_EC2.html#iam-example-instances
+Policy: iam-terraform-read-policy
+Source: https://gist.github.com/arsdehnel/70e292467ced2a39f472ddca44629c08
+
+## Pre-defined Policies from IAM
+AutoScalingReadOnlyAccess
+ResourceGroupsandTagEditorFullAccess

--- a/aws-policies/iam-terraform-read-policy.json
+++ b/aws-policies/iam-terraform-read-policy.json
@@ -1,0 +1,54 @@
+{
+   "Version": "2012-10-17",
+   "Statement": [  {
+       "Effect": "Allow",
+       "Action": [
+           "ec2:DescribeNetworkAcls",
+	   "ec2:DescribeNetworkInterfaceAttribute",
+	   "ec2:DescribeNetworkInterfaces",
+	   "autoscaling:DescribeAutoScalingGroups",
+	   "elasticloadbalancing:DescribeInstanceHealth",
+	   "autoscaling:DescribeLaunchConfigurations",
+	   "ec2:DescribeSecurityGroups",
+	   "ec2:DescribeVpcAttribute",
+	   "ec2:DescribeVpcs",
+	   "ec2:DescribeVpcEndpoints",
+	   "ec2:DescribeVpcPeeringConnections",
+	   "ec2:DescribeSubnets",
+	   "ec2:DescribeImages",
+	   "ec2:DescribeVolumes",
+	   "ec2:DescribeInstances",
+           "ec2:DescribeInstances",
+           "ec2:DescribeInstanceAttribute",
+	   "ec2:DescribeSecurityGroups",
+	   "ec2:DescribeInternetGateways",
+	   "ec2:DescribeRouteTables",
+	   "ec2:DescribeAddresses",
+	   "route53:GetHostedZone",
+	   "route53:ListResourceRecordSets",
+	   "route53:GetHealthCheck",
+	   "route53:ListTagsForResource",
+	   "ec2:DescribeVolumes",
+           "ec2:DescribeTags",
+	   "elasticloadbalancing:DescribeLoadBalancerAttributes",
+	   "elasticloadbalancing:DescribeLoadBalancers",
+	   "elasticloadbalancing:DescribeTags",
+	   "iam:GetInstanceProfile",
+	   "iam:GetPolicy",
+	   "iam:GetRole",
+	   "rds:DescribeDBSubnetGroups",
+	   "elasticloadbalancing:DescribeTargetGroups",
+	   "iam:GetPolicyVersion",
+	   "elasticloadbalancing:DescribeTargetGroupAttributes",
+	   "rds:DescribeDBInstances",
+	   "elasticloadbalancing:DescribeListeners",
+	   "iam:ListEntitiesForPolicy",
+	   "elasticloadbalancing:DescribeRules",
+	   "iam:ListPolicyVersions"
+         ],
+      "Resource": [
+          "*"
+         ]
+   }
+   ]
+}

--- a/aws_instance_located/main.tf
+++ b/aws_instance_located/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+}
+
+variable "region_ami" {}
+
+resource "aws_instance" "gnu_linux" {
+  provider = "aws"
+  ami           = "${var.region_ami}"
+  instance_type = "t2.micro"
+}

--- a/credentials.example
+++ b/credentials.example
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-variable "amis" {
-  type = "map"
-}
-
 # US East (N. Virginia)
 provider "aws" {
   version = "~> 1.5"
@@ -21,7 +17,7 @@ provider "aws" {
 # South America (Sao Paulo)
 provider "aws" {
   version = "~> 1.5"
-  shared_credentials_file = "/vagrant/credentials"
+  shared_credentials_file = "${var.credentials_file}"
   region = "sa-east-1"
   alias = "brasil"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,54 @@
+variable "amis" {
+  type = "map"
+}
+
+# US East (N. Virginia)
+provider "aws" {
+  version = "~> 1.5"
+  shared_credentials_file = "/vagrant/credentials"
+  region = "us-east-1"
+  alias = "virginia"
+}
+
+# EU (Frankfurt)
+provider "aws" {
+  version = "~> 1.5"
+  shared_credentials_file = "/vagrant/credentials"
+  region = "eu-central-1"
+  alias = "europe"
+}
+
+# South America (Sao Paulo)
+provider "aws" {
+  version = "~> 1.5"
+  shared_credentials_file = "/vagrant/credentials"
+  region = "sa-east-1"
+  alias = "brasil"
+}
+
+module "virginia_instance" {
+  source = "./aws_instance_located"
+  region_ami = "${var.amis["virginia"]}"
+
+  providers = {
+    "aws" = "aws.virginia"
+  }
+}
+
+module "europe_instance" {
+  source = "./aws_instance_located"
+  region_ami = "${var.amis["europe"]}"
+
+  providers = {
+    "aws" = "aws.europe"
+  }
+}
+
+module "brasil_instance" {
+  source = "./aws_instance_located"
+  region_ami = "${lookup(var.amis, "brasil")}"
+
+  providers = {
+    "aws" = "aws.brasil"
+  }
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,5 +1,0 @@
-amis = {
-  "virginia" = "ami-55ef662f"
-  "europe" = "ami-bf2ba8d0"
-  "brasil" = "ami-286f2a44"
-}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,5 @@
+amis = {
+  "virginia" = "ami-55ef662f"
+  "europe" = "ami-bf2ba8d0"
+  "brasil" = "ami-286f2a44"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,15 @@
+variable "amis" {
+  type = "map"
+  default = {
+    "virginia" = "ami-55ef662f"
+    "europe" = "ami-bf2ba8d0"
+    "brasil" = "ami-286f2a44"
+    description = "This variable contains that will be used in each region (Virginia, Frankfurt, and Sao Paulo)."
+  }
+}
+
+variable "credentials_file" {
+  type = "string"
+  description = "This variable contains the path to the file with the AWS API credentials."
+  default = "/vagrant/credentials"
+}


### PR DESCRIPTION
Add scripts to provision 3 instances in 3 different regions.
Also include AMI policy examples and update the gitignore file.